### PR TITLE
password 

### DIFF
--- a/app/com/yetu/oauth2provider/controllers/authentication/YetuPasswordValidator.scala
+++ b/app/com/yetu/oauth2provider/controllers/authentication/YetuPasswordValidator.scala
@@ -1,0 +1,20 @@
+package com.yetu.oauth2provider.controllers.authentication
+
+import securesocial.core.providers.utils.PasswordValidator
+
+import com.yetu.oauth2provider.utils.Config
+
+class YetuPasswordValidator extends PasswordValidator {
+
+  override def validate(password: String): Either[(String, Seq[Any]), Unit] = {
+    if (password.length >= Config.minimumPasswordLength) {
+      Right(())
+    } else
+      Left((YetuPasswordValidator.InvalidPasswordMessage, Seq(Config.minimumPasswordLength)))
+  }
+
+}
+
+object YetuPasswordValidator {
+  val InvalidPasswordMessage = "securesocial.signup.invalidPassword"
+}

--- a/app/com/yetu/oauth2provider/controllers/authentication/YetuPasswordValidator.scala
+++ b/app/com/yetu/oauth2provider/controllers/authentication/YetuPasswordValidator.scala
@@ -4,13 +4,35 @@ import securesocial.core.providers.utils.PasswordValidator
 
 import com.yetu.oauth2provider.utils.Config
 
+import scala.util.matching.Regex
+
 class YetuPasswordValidator extends PasswordValidator {
+  class RichRegex(underlying: Regex) {
+    def matches(s: String) = underlying.pattern.matcher(s).matches
+  }
+  implicit def regexToRichRegex(r: Regex) = new RichRegex(r)
+
+  def hasValidLength(implicit password: String): Boolean = {
+    password.length >= Config.minimumPasswordLength
+  }
+  def containsUppercase(implicit password: String): Boolean = {
+    """.*[A-Z]+.*""".r matches password
+  }
+  def containsLowercase(implicit password: String): Boolean = {
+    """.*[a-z]+.*""".r matches password
+  }
+  def containsDigit(implicit password: String): Boolean = {
+    """.*[0-9]+.*""".r matches password
+  }
 
   override def validate(password: String): Either[(String, Seq[Any]), Unit] = {
-    if (password.length >= Config.minimumPasswordLength) {
+    implicit val implicitPassword = password
+
+    if (hasValidLength && containsDigit && containsUppercase && containsLowercase) {
       Right(())
-    } else
+    } else {
       Left((YetuPasswordValidator.InvalidPasswordMessage, Seq(Config.minimumPasswordLength)))
+    }
   }
 
 }

--- a/app/com/yetu/oauth2provider/registry/ControllerRegistry.scala
+++ b/app/com/yetu/oauth2provider/registry/ControllerRegistry.scala
@@ -8,6 +8,7 @@ import com.yetu.oauth2provider.services.data.LdapUserService
 import securesocial.core.RuntimeEnvironment
 import securesocial.core.authenticator.{ AuthenticatorStore, HttpHeaderAuthenticatorBuilder }
 import securesocial.core.providers.UsernamePasswordProvider
+import securesocial.core.providers.utils.PasswordValidator
 import securesocial.core.services.{ AuthenticatorService, UserService }
 
 import scala.collection.immutable.ListMap
@@ -39,6 +40,7 @@ trait AuthenticationControllerRegistry extends ServicesRegistry {
     override lazy val viewTemplates = yetuViewTemplates
     override lazy val userService: UserService[YetuUser] = myUserService
     override lazy val passwordHashers = yetuPasswordHashers
+    override lazy val passwordValidator: PasswordValidator = new YetuPasswordValidator()
     override lazy val providers = ListMap(
       include(new UsernamePasswordProvider[YetuUser](userService, avatarService, viewTemplates, passwordHashers)),
       include(signatureAuthenticationProvider)

--- a/app/com/yetu/oauth2provider/utils/Config.scala
+++ b/app/com/yetu/oauth2provider/utils/Config.scala
@@ -108,5 +108,9 @@ object Config {
   val configWithoutStartedApplication = ConfigFactory.load()
   val databaseToUse = configWithoutStartedApplication.getString("databaseToUse")
 
+  val minimumPasswordLength = configWithoutStartedApplication.getInt("securesocial.userpass.minimumPasswordLength")
+
+  val InvalidPasswordMessage = "securesocial.signup.invalidPassword"
+
 }
 

--- a/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
+++ b/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
@@ -4,10 +4,11 @@
     <label class="control-label" for="@elements.id">@elements.label(elements.lang)</label>
     <div class="controls">
         @elements.input
-	@if( elements.hasErrors ) {
-            <span class="help-inline">@elements.errors(elements.lang).mkString(", ")</span>
+        @if( elements.hasErrors ) {
+            <div class="help-inline">@elements.errors(elements.lang).mkString(", ")</div>
         } else {
-            <span class="help-block">@elements.infos(elements.lang).mkString(", ")</span>
+            <div class="help-block">@elements.infos(elements.lang).mkString(", ")</div>
         }
     </div>
+
 </div>

--- a/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
+++ b/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
@@ -5,13 +5,9 @@
     <div class="controls">
         @elements.input
         @if( elements.hasErrors ) {
-            @if( elements.errors(elements.lang).mkString(", ").contains("Password must contain") ) {
-                <div class="help-inline more-lines">@elements.errors(elements.lang).mkString(", ")</div>
-            }else{
-                <div class="help-inline">@elements.errors(elements.lang).mkString(", ")</div>
-            }
+            <span class="help-inline">@elements.errors(elements.lang).mkString(", ")</span>
         } else {
-            <div class="help-block">@elements.infos(elements.lang).mkString(", ")</div>
+            <span class="help-block">@elements.infos(elements.lang).mkString(", ")</span>
         }
     </div>
 

--- a/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
+++ b/app/com/yetu/oauth2provider/views/yetuAuthentication/inputFieldConstructor.scala.html
@@ -5,7 +5,11 @@
     <div class="controls">
         @elements.input
         @if( elements.hasErrors ) {
-            <div class="help-inline">@elements.errors(elements.lang).mkString(", ")</div>
+            @if( elements.errors(elements.lang).mkString(", ").contains("Password must contain") ) {
+                <div class="help-inline more-lines">@elements.errors(elements.lang).mkString(", ")</div>
+            }else{
+                <div class="help-inline">@elements.errors(elements.lang).mkString(", ")</div>
+            }
         } else {
             <div class="help-block">@elements.infos(elements.lang).mkString(", ")</div>
         }

--- a/conf/messages
+++ b/conf/messages
@@ -41,7 +41,7 @@ securesocial.signup.passwordsDoNotMatch=Passwords do not match.
 securesocial.signup.thankYouCheckEmail=Thank you. Please check your E-Mail for further instructions.
 securesocial.signup.invalidLink=The link you followed is invalid.
 securesocial.signup.signUpDone=Thank you for signing up.
-securesocial.signup.invalidPassword=Enter at least {0} characters.
+securesocial.signup.invalidPassword=Password must contain at least {0} characters, one digit and one uppercase letter.
 securesocial.signup.loginhere=Log in here
 securesocial.signup.welcome=&nbsp;to start your discovery of a new world at home with yetu.me.
 

--- a/conf/messages.de
+++ b/conf/messages.de
@@ -31,7 +31,7 @@ securesocial.signup.passwordsDoNotMatch=Die Passwörter stimmen nicht überein
 securesocial.signup.thankYouCheckEmail=Vielen Dank. Bitte prüfen Sie ihr E-Mail Konto für weitere Schritte.
 securesocial.signup.invalidLink=Der Link ist ungültig
 securesocial.signup.signUpDone=Vielen Dank für Ihre Registrierung.
-securesocial.signup.invalidPassword=Geben Sie mindestens {0} Zeichen ein
+securesocial.signup.invalidPassword=Das Passwort muss mindestens {0} Zeichen, eine Ziffer und einen Großbuchstaben enthalten.
 securesocial.signup.loginhere=Melden Sie sich hier an
 securesocial.signup.welcome= um ihre neue Welt zu Hause mit yetu.me zu erkunden.
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -514,9 +514,14 @@ a.muted:focus {
 }
 
 .help-inline{
-    width: 55%;
+    width: 60%;
     display: inline-block;
     font-size: 14px;
+    vertical-align: super;
+}
+
+.help-inline.more-lines{
+    vertical-align: top;
 }
 
 p.login-instruction{

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -513,6 +513,12 @@ a.muted:focus {
     display:none;
 }
 
+.help-inline{
+    width: 55%;
+    display: inline-block;
+    font-size: 14px;
+}
+
 p.login-instruction{
     margin: 10px 0 0 0;
     padding: 0;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -519,8 +519,7 @@ a.muted:focus {
     font-size: 14px;
     vertical-align: super;
 }
-
-.help-inline.more-lines{
+.control-group:nth-child(5) .help-inline{
     vertical-align: top;
 }
 

--- a/test/com/yetu/oauth2provider/browser/BrowserBaseSpec.scala
+++ b/test/com/yetu/oauth2provider/browser/BrowserBaseSpec.scala
@@ -27,7 +27,7 @@ class BrowserBaseSpec extends PlaySpec
         "smtp.from" -> "test@yetu.me"
       ))
 
-  val browserTestUserPassword = "password"
+  val browserTestUserPassword = "pasSw0rd" // bad password, but enough to pass the basic validation.
 
   def clearMailTokensInMemory() = {
     MemoryMailTokenService.mailTokens = Map[String, MailToken]()

--- a/test/com/yetu/oauth2provider/services/YetuPasswordValidatorSpec.scala
+++ b/test/com/yetu/oauth2provider/services/YetuPasswordValidatorSpec.scala
@@ -1,0 +1,55 @@
+package com.yetu.oauth2provider.services
+
+import com.yetu.oauth2provider.base.BaseSpec
+import com.yetu.oauth2provider.registry.TestRegistry
+import com.yetu.oauth2provider.utils.Config
+import org.scalatestplus.play.OneAppPerSuite
+
+class YetuPasswordValidatorSpec extends BaseSpec with OneAppPerSuite with TestRegistry {
+
+  "Password validator" must {
+    val validator = MyRuntimeEnvironment.passwordValidator
+
+    s"not accept passwords shorter than ${Config.minimumPasswordLength} characters" in {
+
+      val shortPassword = String.format(s"%${Config.minimumPasswordLength - 1}s", "A")
+
+      validator.validate(shortPassword).isLeft mustBe true
+
+    }
+
+    s"accept password longer than ${Config.minimumPasswordLength} characters" in {
+
+      val validPassword = String.format(s"%${Config.minimumPasswordLength}s", "A!a1")
+
+      validator.validate(validPassword).isRight mustBe true
+
+    }
+
+    s"not accept passwords without lowercase characters" in {
+
+      val invalidPassword = String.format(s"%${Config.minimumPasswordLength}s", "A!1")
+
+      validator.validate(invalidPassword).isLeft mustBe true
+
+    }
+
+    s"not accept passwords without uppercase characters" in {
+
+      val invalidPassword = String.format(s"%${Config.minimumPasswordLength}s", "a!1")
+
+      validator.validate(invalidPassword).isLeft mustBe true
+
+    }
+
+    s"not accept passwords without digits" in {
+
+      val invalidPassword = String.format(s"%${Config.minimumPasswordLength}s", "a!A")
+
+      validator.validate(invalidPassword).isLeft mustBe true
+
+    }
+
+  }
+
+}


### PR DESCRIPTION
As requested by https://yetu-dev.atlassian.net/browse/AH-2019 password validation now includes the following rules:
* one uppercase
* one lowercase
* one digit
in addition to the previous 8 characters minimum length.

Minor styling change included as the error message is now longer:

![screen shot 2015-03-27 at 14 41 28](https://cloud.githubusercontent.com/assets/2112744/6869631/cfc93bf8-d495-11e4-936d-52f840188cc9.png)

@ElliDy @mr-mig 