### PR TITLE
Walkthrough problem "error.boolean"

### DIFF
--- a/app/assets/javascripts/form-validator.js
+++ b/app/assets/javascripts/form-validator.js
@@ -9,7 +9,7 @@
 var FormValidator = function(root) {
   this.init = function() {
     root = root || document;
-    var inputs = root.querySelectorAll('input');
+    var inputs = root.querySelectorAll('input[type="text"], input[type="password"]');
     for (var i=0; i < inputs.length; i++) {
       var input = inputs[i];
       // Initialize input's error


### PR DESCRIPTION
avoid to include checkbox in the validator.. this was causing a problem because checkbox doesn't have .value, it is used with checked=.. so in safari the browser get lost and enter in a loop of not acceptance..